### PR TITLE
adding SkipTests atribute

### DIFF
--- a/src/Xunit.SkippableFact.SkipAssemblyTests/SkipAssemblyTests.cs
+++ b/src/Xunit.SkippableFact.SkipAssemblyTests/SkipAssemblyTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+[assembly: SkipTests("skipped by assembly")]
+
+namespace Xunit.SkippableFact.SkipAssemblyTests
+{
+    public class SkipAssemblyTests
+    {
+        [SkippableFact]
+        public void SkipFact()
+        {
+            throw new Exception("should have been skipped");
+        }
+
+        [SkippableTheory]
+        [InlineData("should have been skipped")]
+        public void SkipTheory(string message)
+        {
+            throw new Exception(message);
+        }
+
+        public static IEnumerable<object[]> NonSerializableMemberData
+        {
+            get
+            {
+                yield return new object[] { (Func<string>)(() => "should have been skipped") };
+            }
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(NonSerializableMemberData))]
+        public void SkipTheoryWithNonSerializableArguments(Func<string> message)
+        {
+            throw new Exception(message());
+        }
+
+        [SkippableFact(Skip="method skip")]
+        public void SkipFactWithMethodSkip()
+        {
+            throw new Exception("should have been skipped");
+        }
+
+        [SkippableTheory(Skip = "method skip")]
+        [InlineData("should have been skipped")]
+        public void SkipTheoryWithMethodSkip(string message)
+        {
+            throw new Exception(message);
+        }
+
+        [SkippableTheory(Skip = "method skip")]
+        [MemberData(nameof(NonSerializableMemberData))]
+        public void SkipTheoryWithNonSerializableArgumentsWithMethodSkip(Func<string> message)
+        {
+            throw new Exception(message());
+        }
+    }
+}

--- a/src/Xunit.SkippableFact.SkipAssemblyTests/Xunit.SkippableFact.SkipAssemblyTests.csproj
+++ b/src/Xunit.SkippableFact.SkipAssemblyTests/Xunit.SkippableFact.SkipAssemblyTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;net461;netcoreapp1.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -9,7 +9,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Xunit.SkippableFact.SkipAssemblyTests\Xunit.SkippableFact.SkipAssemblyTests.csproj" />
     <ProjectReference Include="..\Xunit.SkippableFact\Xunit.SkippableFact.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -17,8 +16,5 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/src/Xunit.SkippableFact.SkipAssemblyTests/xunit.runner.json
+++ b/src/Xunit.SkippableFact.SkipAssemblyTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "methodDisplay": "method"
+}

--- a/src/Xunit.SkippableFact.Tests/SkipClassTests.cs
+++ b/src/Xunit.SkippableFact.Tests/SkipClassTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xunit.SkippableFact.Tests
+{
+    [SkipTests("skipped by class")]
+    public class SkipClassTests
+    {
+        [SkippableFact]
+        public void SkipFact()
+        {
+            throw new Exception("should have been skipped");
+        }
+
+        [SkippableTheory]
+        [InlineData("should have been skipped")]
+        public void SkipTheory(string message)
+        {
+            throw new Exception(message);
+        }
+        
+        public static IEnumerable<object[]> NonSerializableMemberData
+        {
+            get
+            {
+                yield return new object[] { (Func<string>)(() => "should have been skipped") };
+            }
+        }
+        
+        [SkippableTheory]
+        [MemberData(nameof(NonSerializableMemberData))]
+        public void SkipTheoryWithNonSerializableArguments(Func<string> message)
+        {
+            throw new Exception(message());
+        }
+
+        [SkippableFact(Skip = "method skip")]
+        public void SkipFactWithMethodSkip()
+        {
+            throw new Exception("should have been skipped");
+        }
+
+        [SkippableTheory(Skip = "method skip")]
+        [InlineData("should have been skipped")]
+        public void SkipTheoryWithMethodSkip(string message)
+        {
+            throw new Exception(message);
+        }
+
+        [SkippableTheory(Skip = "method skip")]
+        [MemberData(nameof(NonSerializableMemberData))]
+        public void SkipTheoryWithNonSerializableArgumentsWithMethodSkip(Func<string> message)
+        {
+            throw new Exception(message());
+        }
+    }
+}

--- a/src/Xunit.SkippableFact.Tests/SkipCollectionDefinition.cs
+++ b/src/Xunit.SkippableFact.Tests/SkipCollectionDefinition.cs
@@ -1,0 +1,9 @@
+﻿namespace Xunit.SkippableFact.Tests
+{
+    [CollectionDefinition(nameof(SkipCollectionDefinition))]
+    // ReSharper disable once InconsistentNaming
+    [SkipTests("skipped by collection")]
+    public class SkipCollectionDefinition
+    {
+    }
+}

--- a/src/Xunit.SkippableFact.Tests/SkipCollectionTests.cs
+++ b/src/Xunit.SkippableFact.Tests/SkipCollectionTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xunit.SkippableFact.Tests
+{
+    [Collection(nameof(SkipCollectionDefinition))]
+    public class SkipCollectionTests
+    {
+        [SkippableFact]
+        public void SkipFact()
+        {
+            throw new Exception("should have been skipped");
+        }
+
+        [SkippableTheory]
+        [InlineData("should have been skipped")]
+        public void SkipTheory(string message)
+        {
+            throw new Exception(message);
+        }
+
+        public static IEnumerable<object[]> NonSerializableMemberData
+        {
+            get
+            {
+                yield return new object[] { (Func<string>)(() => "should have been skipped") };
+            }
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(NonSerializableMemberData))]
+        public void SkipTheoryWithNonSerializableArguments(Func<string> message)
+        {
+            throw new Exception(message());
+        }
+    }
+}

--- a/src/Xunit.SkippableFact.Tests/SkippableFactTestCaseTests.cs
+++ b/src/Xunit.SkippableFact.Tests/SkippableFactTestCaseTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.SkippableFact.Tests
+{
+    public class SkippableFactTestCaseTests
+    {
+        private static readonly DiscoveryOptions DefaultDiscoveryOptions = new DiscoveryOptions();
+        private static readonly SkippableFactDiscoverer Discoverer = GetDiscoverer();
+        private static readonly Type FactAttributeType = typeof(FactAttribute);
+
+        public static IEnumerable<object[]> MethodSkipExpectations
+        {
+            get
+            {
+                yield return new object[] { typeof(SkippableFactTestCaseTests), nameof(SkipFact), null, "Method: method skip" };
+                yield return new object[] { typeof(SkippableFactTestCaseTests), nameof(SkipTheory), null, "Method: method skip" };
+                yield return new object[] { typeof(SkippableFactTestCaseTests), nameof(SkipTheoryWithNonSerializableArguments), null, "Method: method skip" };
+                yield return new object[] { typeof(SkipClassTests), nameof(SkipClassTests.SkipFactWithMethodSkip), null, "Class: skipped by class" };
+                yield return new object[] { typeof(SkipClassTests), nameof(SkipClassTests.SkipTheoryWithMethodSkip), null, "Class: skipped by class" };
+                yield return new object[] { typeof(SkipClassTests), nameof(SkipClassTests.SkipTheoryWithNonSerializableArgumentsWithMethodSkip), null, "Class: skipped by class" };
+                yield return new object[] { typeof(SkipClassTests), nameof(SkipClassTests.SkipFactWithMethodSkip), typeof(SkipCollectionDefinition), "Collection: skipped by collection" };
+                yield return new object[] { typeof(SkipClassTests), nameof(SkipClassTests.SkipTheoryWithMethodSkip), typeof(SkipCollectionDefinition), "Collection: skipped by collection" };
+                yield return new object[] { typeof(SkipClassTests), nameof(SkipClassTests.SkipTheoryWithNonSerializableArgumentsWithMethodSkip), typeof(SkipCollectionDefinition), "Collection: skipped by collection" };
+                yield return new object[] { typeof(SkipAssemblyTests.SkipAssemblyTests), nameof(SkipAssemblyTests.SkipAssemblyTests.SkipFactWithMethodSkip), typeof(SkipCollectionDefinition), "Assembly: skipped by assembly" };
+                yield return new object[] { typeof(SkipAssemblyTests.SkipAssemblyTests), nameof(SkipAssemblyTests.SkipAssemblyTests.SkipTheoryWithMethodSkip), typeof(SkipCollectionDefinition), "Assembly: skipped by assembly" };
+                yield return new object[] { typeof(SkipAssemblyTests.SkipAssemblyTests), nameof(SkipAssemblyTests.SkipAssemblyTests.SkipTheoryWithNonSerializableArgumentsWithMethodSkip), typeof(SkipCollectionDefinition), "Assembly: skipped by assembly" };
+            }
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(MethodSkipExpectations))]
+        public void GivenTest_SkipReason_Is_Expected(Type testClass, string methodName, Type collectionType,
+            string expected)
+        {
+            // Arrange
+            var methodInfo = GetMethodInfo(testClass, methodName);
+            var testMethod = GetTestMethod(testClass, methodInfo, collectionType);
+            var factAttribute = GetFactAttribute(methodInfo);
+            var testCase = Discoverer.Discover(DefaultDiscoveryOptions, testMethod, factAttribute).Single();
+
+            // Act
+            var skipReason = testCase.SkipReason;
+
+            // Asssert
+            Assert.Equal(expected, skipReason);
+        }
+
+        [SkippableFact(Skip = "method skip")]
+        public void SkipFact()
+        {
+        }
+
+        [SkippableTheory(Skip = "method skip")]
+        [InlineData("should have been skipped")]
+        public void SkipTheory(string message)
+        {
+        }
+
+        public static IEnumerable<object[]> NonSerializableMemberData
+        {
+            get
+            {
+                yield return new object[] { (Func<string>)(() => "should have been skipped") };
+            }
+        }
+
+        [SkippableTheory(Skip = "method skip")]
+        [MemberData(nameof(NonSerializableMemberData))]
+        public void SkipTheoryWithNonSerializableArguments(Func<string> message)
+        {
+        }
+
+        private static ReflectionTypeInfo GetCollectionTypeInfo(Type collectionType)
+        {
+            var retval = collectionType == null ? null : new ReflectionTypeInfo(collectionType);
+            return retval;
+        }
+
+        private static SkippableFactDiscoverer GetDiscoverer()
+        {
+            var diagnosticMessageSink = new NullMessageSink();
+            var retval = new SkippableFactDiscoverer(diagnosticMessageSink);
+            return retval;
+        }
+
+        private static IAttributeInfo GetFactAttribute(ReflectionMethodInfo methodInfo)
+        {
+            var customAttributes = methodInfo.GetCustomAttributes(FactAttributeType);
+            var retval = customAttributes.Single();
+            return retval;
+        }
+
+        private static ReflectionMethodInfo GetMethodInfo(Type testClass, string methodName)
+        {
+            var method = testClass.GetMethod(methodName);
+            var retval = new ReflectionMethodInfo(method);
+            return retval;
+        }
+
+        private static TestAssembly GetTestAssembly(Type testClass)
+        {
+            var assembly = testClass.GetTypeInfo().Assembly;
+            var reflectionAssemblyInfo = new ReflectionAssemblyInfo(assembly);
+            var retval = new TestAssembly(reflectionAssemblyInfo);
+            return retval;
+        }
+
+
+        private static TestClass GetTestClass(Type testClass, Type collectionType)
+        {
+            var testCollection = GetTestCollection(testClass, collectionType);
+            var typeInfo = new ReflectionTypeInfo(testClass);
+            var retval = new TestClass(testCollection, typeInfo);
+            return retval;
+        }
+
+        private static TestCollection GetTestCollection(Type testClass, Type collectionType)
+        {
+            var reflectionTypeInfo = GetCollectionTypeInfo(collectionType);
+            var testAssembly = GetTestAssembly(testClass);
+            var retval = new TestCollection(testAssembly, reflectionTypeInfo, "test collection displayName");
+            return retval;
+        }
+
+        private static TestMethod GetTestMethod(Type testClass, IMethodInfo methodInfo, Type collectionType)
+        {
+            var @class = GetTestClass(testClass, collectionType);
+            var retval = new TestMethod(@class, methodInfo);
+            return retval;
+        }
+
+        private class DiscoveryOptions : ITestFrameworkDiscoveryOptions
+        {
+            public TValue GetValue<TValue>(string name)
+            {
+                return default(TValue);
+            }
+
+            public void SetValue<TValue>(string name, TValue value)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Xunit.SkippableFact.sln
+++ b/src/Xunit.SkippableFact.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xunit.SkippableFact.Tests", "Xunit.SkippableFact.Tests\Xunit.SkippableFact.Tests.csproj", "{B6E55EBE-4D2D-48DE-97AF-6058169B517D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xunit.SkippableFact.SkipAssemblyTests", "Xunit.SkippableFact.SkipAssemblyTests\Xunit.SkippableFact.SkipAssemblyTests.csproj", "{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,8 +54,23 @@ Global
 		{B6E55EBE-4D2D-48DE-97AF-6058169B517D}.Release|x64.Build.0 = Release|Any CPU
 		{B6E55EBE-4D2D-48DE-97AF-6058169B517D}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6E55EBE-4D2D-48DE-97AF-6058169B517D}.Release|x86.Build.0 = Release|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Debug|x86.Build.0 = Debug|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Release|x64.Build.0 = Release|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F7F1186-3B7A-460B-96C1-DB10E7DACB69}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ED76CEB0-0081-4E86-A93E-0ACFCAEF5C10}
 	EndGlobalSection
 EndGlobal

--- a/src/Xunit.SkippableFact/Sdk/SkippableFactDiscoverer.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableFactDiscoverer.cs
@@ -102,6 +102,21 @@ namespace Xunit.Sdk
                 base.Deserialize(data);
                 this.SkippingExceptionNames = data.GetValue<string[]>(nameof(this.SkippingExceptionNames));
             }
+
+            protected override string GetSkipReason(IAttributeInfo factAttribute)
+            {
+                var reason = this.TestMethod.GetSkipTestsReason();
+                if (string.IsNullOrEmpty(reason))
+                {
+                    reason = base.GetSkipReason(factAttribute);
+                    if (!string.IsNullOrEmpty(reason))
+                    {
+                        reason = $"Method: {reason}";
+                    }
+                }
+
+                return reason;
+            }
         }
     }
 }

--- a/src/Xunit.SkippableFact/Sdk/SkippableTheoryDiscoverer.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableTheoryDiscoverer.cs
@@ -110,6 +110,21 @@ namespace Xunit.Sdk
                 base.Deserialize(data);
                 this.SkippingExceptionNames = data.GetValue<string[]>(nameof(this.SkippingExceptionNames));
             }
+
+            protected override string GetSkipReason(IAttributeInfo factAttribute)
+            {
+                var reason = this.TestMethod.GetSkipTestsReason();
+                if (string.IsNullOrEmpty(reason))
+                {
+                    reason = base.GetSkipReason(factAttribute);
+                    if (!string.IsNullOrEmpty(reason))
+                    {
+                        reason = $"Method: {reason}";
+                    }
+                }
+
+                return reason;
+            }
         }
     }
 }

--- a/src/Xunit.SkippableFact/Sdk/TestMethodExtensions.cs
+++ b/src/Xunit.SkippableFact/Sdk/TestMethodExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Microsoft Public License (Ms-PL). See LICENSE.txt file in the project root for full license information.
+
+namespace Xunit.Sdk
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Abstractions;
+
+    internal static class TestMethodExtensions
+    {
+        public static string GetSkipTestsReason(this ITestMethod testMethod)
+        {
+            var reason = GetReason(
+                testMethod.TestClass.Class.Assembly.GetCustomAttributes,
+                "Assembly");
+
+            if (string.IsNullOrEmpty(reason) && testMethod.TestClass.TestCollection.CollectionDefinition != null)
+            {
+                reason = GetReason(
+                    testMethod.TestClass.TestCollection.CollectionDefinition.GetCustomAttributes,
+                    "Collection");
+            }
+
+            if (string.IsNullOrEmpty(reason))
+            {
+                reason = GetReason(testMethod.TestClass.Class.GetCustomAttributes, "Class");
+            }
+
+            return reason;
+        }
+
+        private static string GetReason(Func<Type, IEnumerable<IAttributeInfo>> customAttributes, string source)
+        {
+            var skipTestsAttribute = customAttributes(typeof(SkipTestsAttribute)).SingleOrDefault();
+            if (skipTestsAttribute != null)
+            {
+                var reason = (string)skipTestsAttribute.GetConstructorArguments().Single();
+                return $"{source}: {reason}";
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Xunit.SkippableFact/SkipTestsAttribute.cs
+++ b/src/Xunit.SkippableFact/SkipTestsAttribute.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Microsoft Public License (Ms-PL). See LICENSE.txt file in the project root for full license information.
+
+namespace Xunit
+{
+    using System;
+
+    /// <summary>
+    /// Skips all tests contained in class, collection or assembly.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly)]
+    public class SkipTestsAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkipTestsAttribute"/> class.
+        /// </summary>
+        /// <param name="reason">
+        /// The reason the tests are being skipped
+        /// </param>
+        // ReSharper disable once UnusedParameter.Local
+        public SkipTestsAttribute(string reason)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I added an attribute, SKipTests, that can be applied to a test class, test collection or assembly. It allows you to skip whole groups of tests with a single line. I've found this useful to mark out large groups of EF integration tests until I'm ready to modify EF related classes.