### PR TITLE
Add netstandard2.0 build

### DIFF
--- a/src/Xunit.SkippableFact.Tests/Xunit.SkippableFact.Tests.csproj
+++ b/src/Xunit.SkippableFact.Tests/Xunit.SkippableFact.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net461;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -16,8 +16,5 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
+++ b/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;net45;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net45;net452</TargetFrameworks>
     <RootNamespace>Xunit</RootNamespace>
     <CodeAnalysisRuleSet>Xunit.SkippableFact.ruleset</CodeAnalysisRuleSet>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
While `netstandard1.1` does work, the [NETStandard library](https://www.nuget.org/packages/NETStandard.Library/) in 1.x brings along a reference mess. For those on `netstandard2.0`+, this will clean references up quite a bit.