### PR TITLE
Remove NETStandard.Library from netstandard1.x deps

### DIFF
--- a/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
+++ b/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="xunit.extensibility.execution" Version="2.1.0" Condition=" '$(TargetFramework)' == 'net45' " />
     <PackageReference Include="xunit.extensibility.execution" Version="2.2.0" Condition=" '$(TargetFramework)' != 'net45' " />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
   <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">
     <PropertyGroup>


### PR DESCRIPTION
This may substantially simplify the dependency graph when/if xunit.extensibility.execution does the same, and we take an update to depend on that.