### PR TITLE
Skip tests even if SkipException is coming from within Assert.Throws

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.25" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />

--- a/src/Xunit.SkippableFact.Tests/SampleTests.cs
+++ b/src/Xunit.SkippableFact.Tests/SampleTests.cs
@@ -63,5 +63,15 @@ namespace Xunit.SkippableFact.Tests
         {
             Skip.If(skip, "I was told to.");
         }
+
+        [SkippableFact]
+        public void SkipInsideAssertThrows()
+        {
+            Assert.Throws<Exception>(new Action(() =>
+            {
+                Skip.If(true, "Skip inside Assert.Throws");
+                throw new Exception();
+            }));
+        }
     }
 }

--- a/src/Xunit.SkippableFact.Tests/Xunit.SkippableFact.Tests.csproj
+++ b/src/Xunit.SkippableFact.Tests/Xunit.SkippableFact.Tests.csproj
@@ -12,9 +12,12 @@
     <ProjectReference Include="..\Xunit.SkippableFact\Xunit.SkippableFact.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Validation" Version="2.4.15" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Validation" Version="2.4.18" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
   </ItemGroup>
 </Project>

--- a/src/Xunit.SkippableFact/Sdk/SkippableTestMessageBus.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableTestMessageBus.cs
@@ -58,7 +58,8 @@ namespace Xunit.Sdk
             if (failed != null)
             {
                 var outerException = failed.ExceptionTypes.FirstOrDefault();
-                if (outerException != null && Array.IndexOf(this.SkippingExceptionNames, outerException) >= 0)
+                if ((outerException != null && Array.IndexOf(this.SkippingExceptionNames, outerException) >= 0) ||
+                    (outerException == "Xunit.Sdk.ThrowsException" && this.SkippingExceptionNames.Any(e => failed.Messages.Any(m => m.Contains($"Actual:   typeof({e})")))))
                 {
                     this.SkippedCount++;
                     return this.inner.QueueMessage(new TestSkipped(failed.Test, failed.Messages[0]));

--- a/src/Xunit.SkippableFact/Sdk/SkippableTestMessageBus.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableTestMessageBus.cs
@@ -59,7 +59,7 @@ namespace Xunit.Sdk
             {
                 var outerException = failed.ExceptionTypes.FirstOrDefault();
                 if ((outerException != null && Array.IndexOf(this.SkippingExceptionNames, outerException) >= 0) ||
-                    (outerException == "Xunit.Sdk.ThrowsException" && this.SkippingExceptionNames.Any(e => failed.Messages.Any(m => m.Contains($"Actual:   typeof({e})")))))
+                    (outerException == "Xunit.Sdk.ThrowsException" && this.SkippingExceptionNames.Any(e => failed.Messages.Any(m => m.Contains($"Actual:   typeof({typeof(SkipException).FullName})")))))
                 {
                     this.SkippedCount++;
                     return this.inner.QueueMessage(new TestSkipped(failed.Test, failed.Messages[0]));

--- a/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
+++ b/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
@@ -16,10 +16,10 @@
     <PackageTags>xunit testing skipping</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Validation" Version="2.4.15" PrivateAssets="compile;contentfiles;analyzers;build" />
+    <PackageReference Include="Validation" Version="2.4.18" PrivateAssets="compile;contentfiles;analyzers;build" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.1.0" Condition=" '$(TargetFramework)' == 'net45' " />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.2.0" Condition=" '$(TargetFramework)' != 'net45' " />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" Condition=" '$(TargetFramework)' != 'net45' " />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
   <Target Name="SetNuSpecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="GetBuildVersion">


### PR DESCRIPTION
**Updated** in https://github.com/AArnott/Xunit.SkippableFact/pull/12#issuecomment-426479554

-----

As described in https://github.com/xunit/xunit/issues/1722 the `Xunit.Sdk.ThrowsException` that is thrown from a failed execution of `Assert.Throws` (and related) does not capture the exception actually thrown.

The thrown Exception message does however contain the string `Actual: typeof(Xunit.SkipException)` if a `SkipException` was thrown inside the action or function passed to `Assert.Throws`.

Although the solution to search the `ThrowsException` message for that string is far from elegant, it works and can be replaced when https://github.com/xunit/xunit/issues/1722 has been fixed.

Fixes #10.