### PR TITLE
Updates xunit.extensibility.execution to 2.4.2 for non-net45 targets

### DIFF
--- a/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
+++ b/src/Xunit.SkippableFact/Xunit.SkippableFact.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Validation" Version="2.4.18" PrivateAssets="compile;contentfiles;analyzers;build" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.1.0" Condition=" '$(TargetFramework)' == 'net45' " />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.0" Condition=" '$(TargetFramework)' != 'net45' " />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" Condition=" '$(TargetFramework)' != 'net45' " />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
👋hello @AArnott!

We are using `SkippableFact` in our test suite for [Octopus](https://octopus.com/). We're using XUnit 2.4.2 for our tests. 

We currently have a bit of build noise around assembly resolution that looks like this:

```
Microsoft.Common.CurrentVersion.targets(2302, 5): [MSB3277] Found conflicts between different versions of "xunit.core" that could not be resolved.
  
There was a conflict between "xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c" and "xunit.core, Version=2.4.2.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c".
    "xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c" was chosen because it was primary and "xunit.core, Version=2.4.2.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c" was not.
    References which depend on "xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c" [C:\...\.nuget\packages\xunit.extensibility.core\2.4.0\lib\netstandard2.0\xunit.core.dll].
        C:\...\.nuget\packages\xunit.extensibility.core\2.4.0\lib\netstandard2.0\xunit.core.dll
          Project file item includes which caused reference "C:\...\.nuget\packages\xunit.extensibility.core\2.4.0\lib\netstandard2.0\xunit.core.dll".
            C:\...\.nuget\packages\xunit.extensibility.core\2.4.0\lib\netstandard2.0\xunit.core.dll
    References which depend on "xunit.core, Version=2.4.2.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c" [].
```

This is due to `SkippableFact` referencing a slightly outdated version of `XUnit.Extensibility`. 

This PR is just a patch-version bump to the latest version for this dependency to try and eliminate the resolution warnings for people using the latest XUnit 2.x.