### PR TITLE
Ignore xunit.extensibility.execution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: xunit.extensibility.execution


### PR DESCRIPTION
Because as an xunit extension, referencing an older version is preferable so that more folks can use our library.