### PR TITLE
Add skipping tests based on the [SupportedOSPlatform] attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,23 @@ public void TestFunctionalityWhichIsNotSupportedOnSomePlatforms()
 }
 ```
 
+### The [SupportedOSPlatform] attribute
+
+Since version 1.5, `Xunit.SkippableFact` understands the `SupportedOSPlatform` attribute to skip tests on unsupported platforms.
+
+```csharp
+[SkippableFact, SupportedOSPlatform("Windows")]
+public void TestCngKey()
+{
+    var key = CngKey.Create(CngAlgorithm.Sha256);
+    Assert.NotNull(key);
+}
+```
+
+Without `[SupportedOSPlatform("Windows")` the [CA1416](CA1416) code analysis warning would trigger:
+> This call site is reachable on all platforms. 'CngKey. Create(CngAlgorithm)' is only supported on: 'windows'.
+
+Adding `[SupportedOSPlatform("Windows")` both suppresses this platform compatibility warning and skips the test when running on Linux or macOS.
+
 [NuPkg]: https://www.nuget.org/packages/Xunit.SkippableFact
+[CA1416]: https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1416

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ public void TestFunctionalityWhichIsNotSupportedOnSomePlatforms()
 }
 ```
 
-### The [SupportedOSPlatform] attribute
+## The `[SupportedOSPlatform]` attribute
 
 Since version 1.5, `Xunit.SkippableFact` understands the `SupportedOSPlatform` attribute to skip tests on unsupported platforms.
 
@@ -51,10 +51,10 @@ public void TestCngKey()
 }
 ```
 
-Without `[SupportedOSPlatform("Windows")` the [CA1416](CA1416) code analysis warning would trigger:
+Without `[SupportedOSPlatform("Windows")]` the [CA1416][CA1416] code analysis warning would trigger:
 > This call site is reachable on all platforms. 'CngKey. Create(CngAlgorithm)' is only supported on: 'windows'.
 
-Adding `[SupportedOSPlatform("Windows")` both suppresses this platform compatibility warning and skips the test when running on Linux or macOS.
+Adding `[SupportedOSPlatform("Windows")]` both suppresses this platform compatibility warning and skips the test when running on Linux or macOS.
 
 [NuPkg]: https://www.nuget.org/packages/Xunit.SkippableFact
-[CA1416]: https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1416
+[CA1416]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416

--- a/src/Xunit.SkippableFact/Sdk/SkippableFactTestCase.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableFactTestCase.cs
@@ -88,4 +88,10 @@ public class SkippableFactTestCase : XunitTestCase
         base.Deserialize(data);
         this.SkippingExceptionNames = data.GetValue<string[]>(nameof(this.SkippingExceptionNames));
     }
+
+    /// <inheritdoc/>
+    protected override string GetSkipReason(IAttributeInfo factAttribute)
+    {
+        return this.TestMethod.GetPlatformSkipReason() ?? base.GetSkipReason(factAttribute);
+    }
 }

--- a/src/Xunit.SkippableFact/Sdk/SkippableTheoryTestCase.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableTheoryTestCase.cs
@@ -86,4 +86,10 @@ public class SkippableTheoryTestCase : XunitTheoryTestCase
         base.Deserialize(data);
         this.SkippingExceptionNames = data.GetValue<string[]>(nameof(this.SkippingExceptionNames));
     }
+
+    /// <inheritdoc/>
+    protected override string GetSkipReason(IAttributeInfo factAttribute)
+    {
+        return this.TestMethod.GetPlatformSkipReason() ?? base.GetSkipReason(factAttribute);
+    }
 }

--- a/src/Xunit.SkippableFact/Sdk/TestMethodExtensions.cs
+++ b/src/Xunit.SkippableFact/Sdk/TestMethodExtensions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Microsoft Public License (Ms-PL). See LICENSE.txt file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using Xunit.Abstractions;
+
+namespace Xunit.Sdk;
+
+/// <summary>
+/// Extensions methods on <see cref="ITestMethod"/>.
+/// </summary>
+internal static class TestMethodExtensions
+{
+    /// <summary>
+    /// Assesses whether the test method can run on the current platform by looking at the <c>[SupportedOSPlatform]</c> attributes on the test method and on the test class.
+    /// </summary>
+    /// <param name="testMethod">The <see cref="ITestMethod"/>.</param>
+    /// <returns>A description of the supported platforms if the test can not run on the current platform or <see langword="null"/> if the test can run on the current platform.</returns>
+    public static string? GetPlatformSkipReason(this ITestMethod testMethod)
+    {
+#if NET462
+        return null;
+#else
+        var platforms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddPlatforms(platforms, testMethod.Method.GetCustomAttributes("System.Runtime.Versioning.SupportedOSPlatformAttribute"));
+        AddPlatforms(platforms, testMethod.Method.Type.GetCustomAttributes("System.Runtime.Versioning.SupportedOSPlatformAttribute"));
+
+        if (platforms.Count == 0 || platforms.Any(platform => RuntimeInformation.IsOSPlatform(OSPlatform.Create(platform))))
+        {
+            return null;
+        }
+
+        string platformsDescription = platforms.Count == 1 ? platforms.First() : string.Join(", ", platforms.Reverse().Skip(1).Reverse()) + " and " + platforms.Last();
+        return $"Only supported on {platformsDescription}";
+#endif
+    }
+
+#if !NET462
+    private static void AddPlatforms(HashSet<string> platforms, IEnumerable<IAttributeInfo> supportedPlatformAttributes)
+    {
+        foreach (IAttributeInfo supportedPlatformAttribute in supportedPlatformAttributes)
+        {
+            platforms.Add(supportedPlatformAttribute.GetNamedArgument<string>("PlatformName"));
+        }
+    }
+#endif
+}

--- a/src/Xunit.SkippableFact/Sdk/TestMethodExtensions.cs
+++ b/src/Xunit.SkippableFact/Sdk/TestMethodExtensions.cs
@@ -16,7 +16,7 @@ internal static class TestMethodExtensions
     /// </summary>
     /// <param name="testMethod">The <see cref="ITestMethod"/>.</param>
     /// <returns>A description of the supported platforms if the test can not run on the current platform or <see langword="null"/> if the test can run on the current platform.</returns>
-    public static string? GetPlatformSkipReason(this ITestMethod testMethod)
+    internal static string? GetPlatformSkipReason(this ITestMethod testMethod)
     {
 #if NET462
         return null;

--- a/test/Xunit.SkippableFact.Tests/SampleTests.cs
+++ b/test/Xunit.SkippableFact.Tests/SampleTests.cs
@@ -90,10 +90,34 @@ public class SampleTests
         Assert.True(OperatingSystem.IsMacOS(), "This should only run on macOS");
     }
 
+    [SkippableFact, SupportedOSPlatform("macOS10.6")]
+    public void MacOs10_6Minimum()
+    {
+        Assert.True(OperatingSystem.IsMacOSVersionAtLeast(10, 6), "This should only run on macOS 10.6 onwards");
+    }
+
+    [SkippableFact, SupportedOSPlatform("macOS77.7")]
+    public void MacOs77_7Minimum()
+    {
+        Assert.True(OperatingSystem.IsMacOSVersionAtLeast(77, 7), "This should only run on macOS 77.7 onwards");
+    }
+
     [SkippableFact, SupportedOSPlatform("Windows")]
     public void WindowsOnly()
     {
         Assert.True(OperatingSystem.IsWindows(), "This should only run on Windows");
+    }
+
+    [SkippableFact, SupportedOSPlatform("Windows10.0")]
+    public void Windows10Minimum()
+    {
+        Assert.True(OperatingSystem.IsWindowsVersionAtLeast(10), "This should only run on Windows 10.0 onwards");
+    }
+
+    [SkippableFact, SupportedOSPlatform("Windows77.7")]
+    public void Windows77_7Minimum()
+    {
+        Assert.True(OperatingSystem.IsWindowsVersionAtLeast(77, 7), "This should only run on Windows 77.7 onwards");
     }
 
     [SkippableFact, SupportedOSPlatform("Android"), SupportedOSPlatform("Browser")]

--- a/test/Xunit.SkippableFact.Tests/SampleTests.cs
+++ b/test/Xunit.SkippableFact.Tests/SampleTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the Microsoft Public License (Ms-PL). See LICENSE.txt file in the project root for full license information.
 
-using System;
+using System.Runtime.Versioning;
 
 namespace Xunit.SkippableFact.Tests;
 
@@ -76,4 +76,45 @@ public class SampleTests
             throw new Exception();
         }));
     }
+
+#if NET5_0_OR_GREATER
+    [SkippableFact, SupportedOSPlatform("Linux")]
+    public void LinuxOnly()
+    {
+        Assert.True(OperatingSystem.IsLinux(), "This should only run on Linux");
+    }
+
+    [SkippableFact, SupportedOSPlatform("macOS")]
+    public void MacOsOnly()
+    {
+        Assert.True(OperatingSystem.IsMacOS(), "This should only run on macOS");
+    }
+
+    [SkippableFact, SupportedOSPlatform("Windows")]
+    public void WindowsOnly()
+    {
+        Assert.True(OperatingSystem.IsWindows(), "This should only run on Windows");
+    }
+
+    [SkippableFact, SupportedOSPlatform("Android"), SupportedOSPlatform("Browser")]
+    public void AndroidAndBrowserFact()
+    {
+        Assert.True(OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser(), "This should only run on Android and Browser");
+    }
+
+    [SkippableTheory, SupportedOSPlatform("Android"), SupportedOSPlatform("Browser")]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void AndroidAndBrowserTheory(int number)
+    {
+        _ = number;
+        Assert.True(OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser(), "This should only run on Android and Browser");
+    }
+
+    [SkippableFact, SupportedOSPlatform("Android"), SupportedOSPlatform("Browser"), SupportedOSPlatform("Wasi")]
+    public void AndroidAndBrowserAndWasiOnly()
+    {
+        Assert.True(OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi(), "This should only run on Android, Browser and Wasi");
+    }
+#endif
 }

--- a/test/Xunit.SkippableFact.Tests/SampleTests.cs
+++ b/test/Xunit.SkippableFact.Tests/SampleTests.cs
@@ -140,5 +140,13 @@ public class SampleTests
     {
         Assert.True(OperatingSystem.IsAndroid() || OperatingSystem.IsBrowser() || OperatingSystem.IsWasi(), "This should only run on Android, Browser and Wasi");
     }
+
+    [SkippableFact, UnsupportedOSPlatform("Linux"), UnsupportedOSPlatform("macOS"), UnsupportedOSPlatform("Windows")]
+    public void UnsupportedPlatforms()
+    {
+        Assert.False(OperatingSystem.IsLinux());
+        Assert.False(OperatingSystem.IsMacOS());
+        Assert.False(OperatingSystem.IsWindows());
+    }
 #endif
 }


### PR DESCRIPTION
Adding support for `SupportedOSPlatform` is great because this attributes suppresses the CA1416 code analysis warning.

This feature was requested in https://github.com/xunit/xunit/issues/2820 but was not implemented in xUnit.net

> [!IMPORTANT]
> I documented in the README that this feature is available since version 1.5. Please update the README to match the actual version number of the next release.

Ping @sliekens who might be interested in this feature. 😉