### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.12.6",
+      "version": "17.13.1",
       "commands": [
         "dotnet-coverage"
       ],
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.1",
+      "version": "2.78.2",
       "commands": [
         "docfx"
       ],


### PR DESCRIPTION
- **Add docfx verification to build**
- **Fix nb.gv failure during docfx build**
- **Remove double word from boilerplate docfx text**
- **Bump docfx to 2.78.2**
- **Bump dotnet-coverage to 17.13.1**
