### PR TITLE
Preserve test output for dynamically skipped tests

### DIFF
--- a/src/Xunit.SkippableFact/Sdk/SkippableTestMessageBus.cs
+++ b/src/Xunit.SkippableFact/Sdk/SkippableTestMessageBus.cs
@@ -94,7 +94,7 @@ public class SkippableTestMessageBus : IMessageBus
             if (skipTest)
             {
                 this.SkippedCount++;
-                return this.inner.QueueMessage(new TestSkipped(failed.Test, skipReason));
+                return this.inner.QueueMessage(new TestSkippedWithOutput(failed.Test, failed.ExecutionTime, failed.Output, skipReason));
             }
         }
         else if (message is TestCaseFinished tcf)
@@ -132,4 +132,15 @@ public class SkippableTestMessageBus : IMessageBus
 
     private bool ShouldSkipException(string exceptionType) =>
         Array.IndexOf(this.SkippingExceptionNames, exceptionType) >= 0;
+
+    private sealed class TestSkippedWithOutput : TestResultMessage, ITestSkipped
+    {
+        internal TestSkippedWithOutput(ITest test, decimal executionTime, string output, string? reason)
+            : base(test, executionTime, output)
+        {
+            this.Reason = reason;
+        }
+
+        public string? Reason { get; }
+    }
 }

--- a/test/Xunit.SkippableFact.Tests/OutputTests.cs
+++ b/test/Xunit.SkippableFact.Tests/OutputTests.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Microsoft Public License (Ms-PL). See LICENSE.txt file in the project root for full license information.
+
+using Xunit.Abstractions;
+
+namespace Xunit.SkippableFact.Tests;
+
+public class OutputTests(ITestOutputHelper output)
+{
+    [SkippableFact]
+    public void OutputBeforeSkip()
+    {
+        output.WriteLine("Output written before skipping.");
+        Skip.If(true, "Skipped after writing output.");
+    }
+}


### PR DESCRIPTION
Fixes #16.

When a failure is converted into a skipped result, preserve the original result's captured output and execution time instead of using xUnit v2's TestSkipped implementation, which initializes both values to empty/zero.

Adds a regression test that writes through ITestOutputHelper before dynamically skipping.